### PR TITLE
refactor: getFileTree의 쿼리 호출 횟수 최적화

### DIFF
--- a/src/main/java/goorm/fullstack/webide/domain/File.java
+++ b/src/main/java/goorm/fullstack/webide/domain/File.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,10 +38,10 @@ public class File extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
     @Column
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<File> files;
     @JoinColumn
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private File parent;
 
     public FileResponseDto toDto() {
@@ -59,5 +58,9 @@ public class File extends BaseTimeEntity {
 
     public void moveTo(File parent) {
         this.parent = parent;
+    }
+
+    public boolean hasParent() {
+        return this.parent != null;
     }
 }

--- a/src/main/java/goorm/fullstack/webide/dto/FileTreeNodeDto.java
+++ b/src/main/java/goorm/fullstack/webide/dto/FileTreeNodeDto.java
@@ -3,17 +3,18 @@ package goorm.fullstack.webide.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import goorm.fullstack.webide.domain.File;
+import java.util.ArrayList;
 import java.util.List;
 
-public record FileTreeNodeDto(int id, String name, Boolean isFolder, @JsonInclude(Include.NON_NULL) List<FileTreeNodeDto> files) {
-    public FileTreeNodeDto {
-        if (!isFolder) {
-            files = null;
-        }
+public record FileTreeNodeDto(int id, String name, Boolean isFolder,
+                              @JsonInclude(Include.NON_NULL) List<FileTreeNodeDto> files) {
+    public FileTreeNodeDto(File file) {
+        // todo: 파라미터가 폴더일 때 ArrayList를 만들게 되는데, runCode에서 지적받았던 것처럼
+        //  폴더 안에 하위 폴더나 파일이 엄청 많을 때 계속 array를 두 배로 늘리는 작업이 예상된다.
+        this(file.getId(), file.getName(), file.getIsFolder(), file.getIsFolder() ? new ArrayList<>() : null);
     }
 
-    public FileTreeNodeDto(File file) {
-        this(file.getId(), file.getName(), file.getIsFolder(),
-            file.getFiles().stream().map(FileTreeNodeDto::new).toList());
+    public void addFileTreeNodeDto(FileTreeNodeDto fileTreeNodeDto) {
+        files.add(fileTreeNodeDto);
     }
 }

--- a/src/main/java/goorm/fullstack/webide/repository/FileJpaRepository.java
+++ b/src/main/java/goorm/fullstack/webide/repository/FileJpaRepository.java
@@ -3,11 +3,20 @@ package goorm.fullstack.webide.repository;
 import goorm.fullstack.webide.domain.File;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface FileJpaRepository extends JpaRepository<File, Integer> {
+
+    // 특정 폴더 하위에 있는 모든 파일과 폴더를 리스트로 반환하는 NativeQuery 함수
+    @Query(value = """
+        WITH RECURSIVE file_tree AS (
+            SELECT id, name, is_folder, content, parent_id, created_at, updated_at, user_id FROM file WHERE id = ?1
+            UNION ALL
+            SELECT f.id, f.name, f.is_folder, f.content, f.parent_id, f.created_at, f.updated_at, f.user_id FROM file f 
+            INNER JOIN file_tree ft ON f.parent_id = ft.id
+        ) SELECT * FROM file_tree
+        """, nativeQuery = true)
+    List<File> findAllFilesInFolder(int id);
 }

--- a/src/main/java/goorm/fullstack/webide/service/ProjectService.java
+++ b/src/main/java/goorm/fullstack/webide/service/ProjectService.java
@@ -8,8 +8,9 @@ import goorm.fullstack.webide.dto.ProjectRequestDto;
 import goorm.fullstack.webide.repository.FileJpaRepository;
 import goorm.fullstack.webide.repository.ProjectRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -51,16 +52,42 @@ public class ProjectService implements OwnableValidation {
     }
 
     public FileTreeNodeDto getFileTree(int projectId) {
+        // 프로젝트의 루트 폴더를 최상위로 두는 하위 폴더, 파일들을 전부 가져온다.
         Project project = projectRepository.findById(projectId)
             .orElseThrow(EntityNotFoundException::new);
         File rootFolder = project.getRootFolder();
-        return new FileTreeNodeDto(rootFolder);
+
+        return makeFileTree(fileJpaRepository.findAllFilesInFolder(rootFolder.getId()));
+    }
+
+    private FileTreeNodeDto makeFileTree(List<File> files) {
+        Map<Integer, FileTreeNodeDto> fileTreeNodeDtoMap = new HashMap<>();
+
+        // 먼저 조회된 모든 파일들을 FileTreeNodeDto로 변환하여 map에 저장한다.
+        for (File file : files) {
+            fileTreeNodeDtoMap.put(file.getId(), new FileTreeNodeDto(file));
+        }
+
+        // 그 다음 map에 추가한 값들을 이용하여 트리 구조를 생성한다.
+        FileTreeNodeDto fileTree = null;
+        for (File file : files) {
+            FileTreeNodeDto fileTreeNodeDto = fileTreeNodeDtoMap.get(file.getId());
+            // 파일의 부모가 없다는건 이 파일이 루트 폴더임을 의미
+            if (!file.hasParent()) {
+                fileTree = fileTreeNodeDto;
+                continue;
+            }
+            FileTreeNodeDto parentFileTreeNodeDto = fileTreeNodeDtoMap.get(file.getParent().getId());
+            parentFileTreeNodeDto.addFileTreeNodeDto(fileTreeNodeDto);
+        }
+        return fileTree;
     }
 
     @Override
     public boolean isOwner(int resourceId) {
         User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        Project project = projectRepository.findById(resourceId).orElseThrow(EntityNotFoundException::new);
+        Project project = projectRepository.findById(resourceId)
+            .orElseThrow(EntityNotFoundException::new);
         return project.getUser().getUserId() == user.getUserId();
     }
 }


### PR DESCRIPTION
# PR 유형

<!-- 어떤 변경 사항이 있나요? -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 빌드 부분 혹은 패키지 매니저 수정

# PR 내용 요약

<!-- 이 PR로 인한 변경점을 서술해주세요. -->
`WITH RECURSIVE`로 특정 폴더 하위의 모든 파일과 폴더를 조회하는 SQL을 작성하고, 이를 실행하는 함수를 만들었습니다.
리포지토리 레이어에서 파일트리를 생성하지 않고 서비스레이어에서 파일트리를 생성하도록 작성했습니다. 쿼리 횟수를 1번으로 줄이는 대신 시간복잡도가 $O(n)$인 알고리즘을 구현하여 파일트리를 생성했습니다.
